### PR TITLE
chore: remove default features from reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ ethers-core = { version = "2", default-features = false }
 
 foundry-compilers = { version = "0.1", optional = true }
 
-reqwest = { version = "0.11.19", features = ["json"] }
+reqwest = { version = "0.11.19", default-features = false, features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"


### PR DESCRIPTION
This was pulling in `openssl`, which we don't want.