### PR TITLE
Do not error if the source code is not verified

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -391,14 +391,6 @@ impl Client {
             self.create_query("contract", "getsourcecode", HashMap::from([("address", address)]));
         let response = self.get(&query).await?;
 
-        // Source code is not verified
-        if response.contains("Contract source code not verified") {
-            if let Some(ref cache) = self.cache {
-                cache.set_source(address, None);
-            }
-            return Err(EtherscanError::ContractCodeNotVerified(address));
-        }
-
         let response: Response<ContractMetadata> = self.sanitize_response(response)?;
         let result = response.result;
 

--- a/tests/it/contract.rs
+++ b/tests/it/contract.rs
@@ -49,18 +49,6 @@ async fn can_fetch_contract_source_code() {
     .await
 }
 
-#[tokio::test]
-#[serial]
-async fn can_get_error_on_unverified_contract() {
-    init_tracing();
-    run_with_client(Chain::mainnet(), |client| async move {
-        let addr = "0xb5c31a0e22cae98ac08233e512bd627885aa24e5".parse().unwrap();
-        let err = client.contract_source_code(addr).await.unwrap_err();
-        assert!(matches!(err, EtherscanError::ContractCodeNotVerified(_)));
-    })
-    .await
-}
-
 /// Query a contract that has a single string source entry instead of underlying JSON metadata.
 #[tokio::test]
 #[serial]


### PR DESCRIPTION
When fetching the source code for a proxy contract, the source code is most likely not verified. In the current implementation, the code returns an error and makes it impossible to detect the implementation address in order to make the same request against that address.

This change makes it possible to proceed with the request even if the source code is not verified, and allow the caller to control the flow from there.

I could see a potentially different implementation where we return a different error that contains the address of the implementation contract if that is preferred.

Wdyt?