### PR TITLE
fix: sanitize all source entries

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -218,7 +218,12 @@ impl Metadata {
         self.sources()
             .into_iter()
             .map(|(path, entry)| {
-                let path = root.join(path);
+                // This is relevant because the etherscan [Metadata](crate::contract::Metadata) can
+                // contain absolute paths (supported by standard-json-input). See also: <https://github.com/foundry-rs/foundry/issues/6541>
+                // for example, we want to ensure "/contracts/SimpleToken.sol" is mapped to
+                // `<root_dir>/contracts/SimpleToken.sol`.
+                let sanitized_path = crate::source_tree::sanitize_path(path);
+                let path = root.join(sanitized_path);
                 SourceTreeEntry { path, contents: entry.content }
             })
             .collect()

--- a/src/source_tree.rs
+++ b/src/source_tree.rs
@@ -36,8 +36,9 @@ impl SourceTree {
 }
 
 /// Remove any components in a smart contract source path that could cause a directory traversal.
-fn sanitize_path(path: &Path) -> PathBuf {
-    let sanitized = Path::new(path)
+pub(crate) fn sanitize_path(path: impl AsRef<Path>) -> PathBuf {
+    let sanitized = path
+        .as_ref()
         .components()
         .filter(|x| x.as_os_str() != Component::ParentDir.as_os_str())
         .collect::<PathBuf>();


### PR DESCRIPTION
ref https://github.com/foundry-rs/foundry/issues/6541

this fixes a bug where the source tree can have folder outside the targeted `root dir` because the path can be absolute (standard json thing)

ref https://github.com/foundry-rs/block-explorers/pull/19