### PR TITLE
Fix deserialization failure when fetching contract source_code from blockscout

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,5 +1,5 @@
 use crate::{
-    serde_helpers::{deserialize_stringified_u64, deserialize_stringified_bool_or_u64},
+    serde_helpers::{deserialize_stringified_bool_or_u64, deserialize_stringified_u64},
     source_tree::{SourceTree, SourceTreeEntry},
     utils::{deserialize_address_opt, deserialize_source_code},
     Client, EtherscanError, Response, Result,
@@ -132,7 +132,7 @@ pub struct Metadata {
     pub optimization_used: u64,
 
     /// The number of optimizations performed.
-    #[serde(deserialize_with = "deserialize_stringified_u64", alias="OptimizationRuns")]
+    #[serde(deserialize_with = "deserialize_stringified_u64", alias = "OptimizationRuns")]
     pub runs: u64,
 
     /// The constructor arguments the contract was deployed with.
@@ -153,7 +153,7 @@ pub struct Metadata {
     pub license_type: String,
 
     /// Whether this contract is a proxy. This value should only be 0 or 1.
-    #[serde(deserialize_with = "deserialize_stringified_bool_or_u64", alias="IsProxy")]
+    #[serde(deserialize_with = "deserialize_stringified_bool_or_u64", alias = "IsProxy")]
     pub proxy: u64,
 
     /// If this contract is a proxy, the address of its implementation.

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,5 +1,5 @@
 use crate::{
-    serde_helpers::deserialize_stringified_u64,
+    serde_helpers::{deserialize_stringified_u64, deserialize_stringified_bool_or_u64},
     source_tree::{SourceTree, SourceTreeEntry},
     utils::{deserialize_address_opt, deserialize_source_code},
     Client, EtherscanError, Response, Result,
@@ -128,14 +128,15 @@ pub struct Metadata {
     pub compiler_version: String,
 
     /// Whether the optimizer was used. This value should only be 0 or 1.
-    #[serde(deserialize_with = "deserialize_stringified_u64")]
+    #[serde(deserialize_with = "deserialize_stringified_bool_or_u64")]
     pub optimization_used: u64,
 
     /// The number of optimizations performed.
-    #[serde(deserialize_with = "deserialize_stringified_u64")]
+    #[serde(deserialize_with = "deserialize_stringified_u64", alias="OptimizationRuns")]
     pub runs: u64,
 
     /// The constructor arguments the contract was deployed with.
+    #[serde(default)]
     pub constructor_arguments: Bytes,
 
     /// The version of the EVM the contract was deployed in. Can be either a variant of EvmVersion
@@ -144,13 +145,15 @@ pub struct Metadata {
     pub evm_version: String,
 
     // ?
+    #[serde(default)]
     pub library: String,
 
     /// The license of the contract.
+    #[serde(default)]
     pub license_type: String,
 
     /// Whether this contract is a proxy. This value should only be 0 or 1.
-    #[serde(deserialize_with = "deserialize_stringified_u64")]
+    #[serde(deserialize_with = "deserialize_stringified_bool_or_u64", alias="IsProxy")]
     pub proxy: u64,
 
     /// If this contract is a proxy, the address of its implementation.
@@ -162,6 +165,7 @@ pub struct Metadata {
     pub implementation: Option<Address>,
 
     /// The swarm source of the contract.
+    #[serde(default)]
     pub swarm_source: String,
 }
 

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -46,7 +46,6 @@ impl TryFrom<StringifiedNumeric> for U64 {
     }
 }
 
-
 #[derive(Deserialize)]
 #[serde(untagged)]
 enum BoolOrU64 {
@@ -55,8 +54,7 @@ enum BoolOrU64 {
     Bool(String),
 }
 
-
-/// Supports parsing either a u64 or a boolean (which will then be converted to u64) 
+/// Supports parsing either a u64 or a boolean (which will then be converted to u64)
 /// Implemented to binary fields such as "OptimizationUsed" which are formatted either as 0/1 or
 /// "true/"false" by different block explorers (e.g. etherscan vs blockscout)
 pub fn deserialize_stringified_bool_or_u64<'de, D>(deserializer: D) -> Result<u64, D::Error>

--- a/tests/it/contract.rs
+++ b/tests/it/contract.rs
@@ -34,7 +34,14 @@ async fn can_fetch_contract_abi() {
 #[tokio::test]
 #[serial]
 async fn can_fetch_contract_source_code_from_blockscout() {
-    let client = Client::builder().with_url("https://eth.blockscout.com").unwrap().with_api_url("https://eth.blockscout.com/api").unwrap().with_api_key("test").build().unwrap();
+    let client = Client::builder()
+        .with_url("https://eth.blockscout.com")
+        .unwrap()
+        .with_api_url("https://eth.blockscout.com/api")
+        .unwrap()
+        .with_api_key("test")
+        .build()
+        .unwrap();
     let meta = client
         .contract_source_code("0x00000000219ab540356cBB839Cbe05303d7705Fa".parse().unwrap())
         .await

--- a/tests/it/contract.rs
+++ b/tests/it/contract.rs
@@ -33,6 +33,22 @@ async fn can_fetch_contract_abi() {
 
 #[tokio::test]
 #[serial]
+async fn can_fetch_contract_source_code_from_blockscout() {
+    let client = Client::builder().with_url("https://eth.blockscout.com").unwrap().with_api_url("https://eth.blockscout.com/api").unwrap().with_api_key("test").build().unwrap();
+    let meta = client
+        .contract_source_code("0x00000000219ab540356cBB839Cbe05303d7705Fa".parse().unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(meta.items.len(), 1);
+    let item = &meta.items[0];
+    assert!(matches!(item.source_code, SourceCodeMetadata::SourceCode(_)));
+    assert_eq!(item.source_code.sources().len(), 1);
+    assert_eq!(item.abi().unwrap(), serde_json::from_str(DEPOSIT_CONTRACT_ABI).unwrap());
+}
+
+#[tokio::test]
+#[serial]
 async fn can_fetch_contract_source_code() {
     run_with_client(Chain::mainnet(), |client| async move {
         let meta = client


### PR DESCRIPTION
[Blockscouts](eth.blockscout.com) response upon requesting a contracts source code diverges from that of etherscan and is thereby incompatible with the current serde deserialization schema:
1. Use "true" / "false" instead of "1"/"0" for various binary fields (e.g. "OptimizationUsed")
2. Different naming of certain fields (e.g. "IsProxy" vs. "Proxy")
3. Omitting fields entirely when data would be empty instead of returning an empty string (e.g. "ConstructorArguments").

For reference compare the [blockscout](https://eth.blockscout.com/api?module=contract&action=getsourcecode&address=0x00000000219ab540356cBB839Cbe05303d7705Fa) and [etherscan](https://api.etherscan.io/api?module=contract&action=getsourcecode&address=0x00000000219ab540356cbb839cbe05303d7705fa) example response for the ETH deposit contract.

This PR fixes that by adjusting the serde deserialization options accordingly.

This partially addresses https://github.com/foundry-rs/block-explorers/issues/21