### PR TITLE
chore: include value in serde error

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,8 +22,8 @@ pub enum EtherscanError {
     EnvVarNotFound(#[from] VarError),
     #[error(transparent)]
     Reqwest(#[from] reqwest::Error),
-    #[error(transparent)]
-    Serde(#[from] serde_json::Error),
+    #[error("Failed to deserialize content: {error}\n{content}")]
+    Serde { error: serde_json::Error, content: String },
     #[error("Contract source code not verified: {0}")]
     ContractCodeNotVerified(Address),
     #[error("Response result is unexpectedly empty: status={status}, message={message}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,8 +225,8 @@ impl Client {
     /// Perform sanity checks on a response and deserialize it into a [Response].
     fn sanitize_response<T: DeserializeOwned>(&self, res: impl AsRef<str>) -> Result<Response<T>> {
         let res = res.as_ref();
-        let res: ResponseData<T> = serde_json::from_str(res).map_err(|err| {
-            error!(target: "etherscan", ?res, "Failed to deserialize response: {}", err);
+        let res: ResponseData<T> = serde_json::from_str(res).map_err(|error| {
+            error!(target: "etherscan", ?res, "Failed to deserialize response: {}", error);
             if res == "Page not found" {
                 EtherscanError::PageNotFound
             } else if is_blocked_by_cloudflare_response(res) {
@@ -234,7 +234,7 @@ impl Client {
             } else if is_cloudflare_security_challenge(res) {
                 EtherscanError::CloudFlareSecurityChallenge
             } else {
-                EtherscanError::Serde(err)
+                EtherscanError::Serde { error, content: res.to_string() }
             }
         })?;
 


### PR DESCRIPTION
a few etherscan APIs are truly bad.
A lot of them randomly send HTML content instead of proper json errors, resulting in unhelpful error messages:

> expected value at line 1 column 1


we already have a few checks for HTML content but because we don't capture the content we cant easily add more.

this includes the content in the error message, so even if this could make the error message very verbose, this is still more helpful because now we easily get reference data.