### PR TITLE
The EVM version returned by Blockscout is "default" 

### DIFF
--- a/crates/block-explorers/src/contract.rs
+++ b/crates/block-explorers/src/contract.rs
@@ -273,8 +273,8 @@ impl Metadata {
     /// Parses the EVM version.
     #[cfg(feature = "foundry-compilers")]
     pub fn evm_version(&self) -> Result<Option<EvmVersion>> {
-        match self.evm_version.as_str() {
-            "" | "Default" => {
+        match self.evm_version.to_lowercase().as_str() {
+            "" | "default" => {
                 Ok(EvmVersion::default().normalize_version_solc(&self.compiler_version()?))
             }
             _ => {

--- a/crates/block-explorers/src/lib.rs
+++ b/crates/block-explorers/src/lib.rs
@@ -438,7 +438,13 @@ impl Cache {
     }
 
     fn set<T: Serialize>(&self, prefix: &str, address: Address, item: T) {
-        let path = self.root.join(prefix).join(format!("{address:?}.json"));
+        // Create the cache directory if it does not exist.
+        let path = self.root.join(prefix);
+        if std::fs::create_dir_all(&path).is_err() {
+            return;
+        }
+
+        let path = path.join(format!("{address:?}.json"));
         let writer = std::fs::File::create(path).ok().map(std::io::BufWriter::new);
         if let Some(mut writer) = writer {
             let _ = serde_json::to_writer(


### PR DESCRIPTION
Unlike Etherscan, Blockscout will return evm version as `default` (all in lower cases). In that case, the attached code would fail and return an error.

https://github.com/foundry-rs/block-explorers/blob/19681285ba4d11cd420d3e5756c4a97113160d90/crates/block-explorers/src/contract.rs#L274-L289