### PR TITLE
chore(deps): bump compilers

### DIFF
--- a/crates/block-explorers/Cargo.toml
+++ b/crates/block-explorers/Cargo.toml
@@ -37,7 +37,7 @@ thiserror = "1.0"
 tracing = "0.1.37"
 semver = "1.0"
 
-foundry-compilers = { version = "0.10", optional = true }
+foundry-compilers = { version = "0.11", optional = true }
 
 [dev-dependencies]
 tempfile = "3.8"


### PR DESCRIPTION
Bump foundry-compilers to `0.11`

Required in https://github.com/foundry-rs/foundry/pull/8771 