### PR TITLE
fix: align  with new API res

### DIFF
--- a/crates/blob-explorers/src/lib.rs
+++ b/crates/blob-explorers/src/lib.rs
@@ -236,10 +236,9 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    #[ignore]
     async fn get_block_by_id() {
-        let block = "0xc3a0113f60107614d1bba950799903dadbc2116256a40b1fefb37e9d409f1866";
-        let client = Client::holesky();
+        let block = "0xb8f7550185a9194ecfe581045c906682a8da6a528a23127e3a5a2abb50b706bf";
+        let client = Client::mainnet();
 
         let _block = client.block(block.parse().unwrap()).await.unwrap();
         for (_tx, _sidecar) in _block.blob_sidecars() {

--- a/crates/blob-explorers/src/response.rs
+++ b/crates/blob-explorers/src/response.rs
@@ -96,6 +96,7 @@ pub struct BlobInfo {
     /// The versioned hash of the blob
     pub versioned_hash: B256,
     /// Storage info
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub data_storage_references: Vec<DataStorageReference>,
     /// The blob data
     #[serde(deserialize_with = "deserialize_blob")]
@@ -110,13 +111,11 @@ pub struct BlobInfo {
 
 /// Where the blob data is stored
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase", default)]
+#[serde(rename_all = "camelCase")]
 pub struct DataStorageReference {
     /// The storage provider
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub blob_storage: Option<String>,
     /// data location
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_reference: Option<String>,
 }
 

--- a/crates/blob-explorers/src/response.rs
+++ b/crates/blob-explorers/src/response.rs
@@ -111,10 +111,13 @@ pub struct BlobInfo {
 /// Where the blob data is stored
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(default)]
 pub struct DataStorageReference {
     /// The storage provider
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub blob_storage: Option<String>,
     /// data location
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub data_reference: Option<String>,
 }
 

--- a/crates/blob-explorers/src/response.rs
+++ b/crates/blob-explorers/src/response.rs
@@ -110,8 +110,7 @@ pub struct BlobInfo {
 
 /// Where the blob data is stored
 #[derive(Default, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[serde(default)]
+#[serde(rename_all = "camelCase", default)]
 pub struct DataStorageReference {
     /// The storage provider
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/blob-explorers/src/response.rs
+++ b/crates/blob-explorers/src/response.rs
@@ -113,9 +113,9 @@ pub struct BlobInfo {
 #[serde(rename_all = "camelCase")]
 pub struct DataStorageReference {
     /// The storage provider
-    pub blob_storage: String,
+    pub blob_storage: Option<String>,
     /// data location
-    pub data_reference: String,
+    pub data_reference: Option<String>,
 }
 
 /// Response for a transaction.


### PR DESCRIPTION
Update Blobscan API integration to match new schema

The Blobscan team has updated their API, removing `DataStorageReference` from the `getBlockById` method response. This PR aligns with new API schema at https://api.blobscan.com/#/blocks/block-getByBlockId :

- Makes `DataStorageReference` fields optional (Option<T>)
- Updates the `get_block_by_id` test with a mainnet block hash 