### PR TITLE
Bump compilers to 0.16.0

### DIFF
--- a/crates/block-explorers/Cargo.toml
+++ b/crates/block-explorers/Cargo.toml
@@ -37,7 +37,7 @@ thiserror = "1.0"
 tracing = "0.1.37"
 semver = "1.0"
 
-foundry-compilers = { version = "0.14", optional = true }
+foundry-compilers = { version = "0.16.0", optional = true }
 
 [dev-dependencies]
 tempfile = "3.8"


### PR DESCRIPTION
- prereq for forge lint PR https://github.com/foundry-rs/foundry/pull/10405