### PR TITLE
fix: Etherscan V2 API URLs from `alloy-chains` already contain `chainid`

### DIFF
--- a/crates/block-explorers/src/errors.rs
+++ b/crates/block-explorers/src/errors.rs
@@ -40,8 +40,6 @@ pub enum EtherscanError {
     Unknown(String),
     #[error("Missing field: {0}")]
     Builder(String),
-    #[error("Failed to serialize query parameters: {0}")]
-    QuerySerializationFailed(String),
     #[error("Missing solc version: {0}")]
     MissingSolcVersion(String),
     #[error("Invalid API Key")]

--- a/crates/block-explorers/src/errors.rs
+++ b/crates/block-explorers/src/errors.rs
@@ -40,6 +40,8 @@ pub enum EtherscanError {
     Unknown(String),
     #[error("Missing field: {0}")]
     Builder(String),
+    #[error("Failed to serialize query parameters: {0}")]
+    QuerySerializationFailed(String),
     #[error("Missing solc version: {0}")]
     MissingSolcVersion(String),
     #[error("Invalid API Key")]

--- a/crates/block-explorers/src/lib.rs
+++ b/crates/block-explorers/src/lib.rs
@@ -198,7 +198,6 @@ impl Client {
         &self.etherscan_api_version
     }
 
-    /// Returns the configured etherscan api url.
     pub fn etherscan_api_url(&self) -> &Url {
         &self.etherscan_api_url
     }
@@ -245,8 +244,8 @@ impl Client {
         let response = self
             .client
             .get(self.etherscan_api_url.clone())
-            .query(query)
             .header(header::ACCEPT, "application/json")
+            .query(query)
             .send()
             .await?
             .text()

--- a/crates/block-explorers/src/lib.rs
+++ b/crates/block-explorers/src/lib.rs
@@ -343,7 +343,6 @@ impl Client {
             apikey: self.api_key.as_deref().map(Cow::Borrowed),
             module: Cow::Borrowed(module),
             action: Cow::Borrowed(action),
-            chain_id: self.chain_id,
             other,
         }
     }
@@ -613,8 +612,6 @@ struct Query<'a, T: Serialize> {
     apikey: Option<Cow<'a, str>>,
     module: Cow<'a, str>,
     action: Cow<'a, str>,
-    #[serde(rename = "chainid", skip_serializing_if = "Option::is_none")]
-    chain_id: Option<u64>,
     #[serde(flatten)]
     other: T,
 }

--- a/crates/block-explorers/src/lib.rs
+++ b/crates/block-explorers/src/lib.rs
@@ -259,6 +259,8 @@ impl Client {
             (k, val)
         }));
 
+        println!("Etherscan API URL: {}", url);
+
         let response = self
             .client
             .get(url)

--- a/crates/block-explorers/src/lib.rs
+++ b/crates/block-explorers/src/lib.rs
@@ -613,7 +613,7 @@ struct Query<'a, T: Serialize> {
     apikey: Option<Cow<'a, str>>,
     module: Cow<'a, str>,
     action: Cow<'a, str>,
-    #[serde(rename = "chainId", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "chainid", skip_serializing_if = "Option::is_none")]
     chain_id: Option<u64>,
     #[serde(flatten)]
     other: T,

--- a/crates/block-explorers/src/lib.rs
+++ b/crates/block-explorers/src/lib.rs
@@ -240,7 +240,6 @@ impl Client {
     /// Execute a GET request with parameters, without sanity checking the response.
     async fn get<Q: Serialize>(&self, query: &Q) -> Result<String> {
         trace!(target: "etherscan", "GET {}", self.etherscan_api_url);
-
         let response = self
             .client
             .get(self.etherscan_api_url.clone())
@@ -250,7 +249,6 @@ impl Client {
             .await?
             .text()
             .await?;
-
         Ok(response)
     }
 

--- a/crates/block-explorers/src/lib.rs
+++ b/crates/block-explorers/src/lib.rs
@@ -331,7 +331,7 @@ impl Client {
     }
 
     fn url_contains_chainid(&self) -> bool {
-        self.etherscan_api_url.query_pairs().any(|(key, _)| key == "chainid")
+        self.etherscan_api_url.query_pairs().any(|(key, _)| key.eq_ignore_ascii_case("chainid"))
     }
 }
 

--- a/crates/block-explorers/src/lib.rs
+++ b/crates/block-explorers/src/lib.rs
@@ -262,12 +262,14 @@ impl Client {
     async fn post<F: Serialize>(&self, form: &F) -> Result<String> {
         trace!(target: "etherscan", "POST {}", self.etherscan_api_url);
 
-        let post_query = match self.chain_id {
-            Some(chain_id) if self.etherscan_api_version == EtherscanApiVersion::V2 => {
-                HashMap::from([("chainid", chain_id)])
-            }
-            _ => HashMap::new(),
-        };
+        let mut post_query = HashMap::new();
+
+        if self.etherscan_api_version == EtherscanApiVersion::V2
+            && self.chain_id.is_some()
+            && !self.url_contains_chainid()
+        {
+            post_query.insert("chainid", self.chain_id.unwrap());
+        }
 
         let response = self
             .client
@@ -278,6 +280,7 @@ impl Client {
             .await?
             .text()
             .await?;
+
         Ok(response)
     }
 
@@ -322,8 +325,13 @@ impl Client {
             apikey: self.api_key.as_deref().map(Cow::Borrowed),
             module: Cow::Borrowed(module),
             action: Cow::Borrowed(action),
+            chain_id: if self.url_contains_chainid() { None } else { self.chain_id },
             other,
         }
+    }
+
+    fn url_contains_chainid(&self) -> bool {
+        self.etherscan_api_url.query_pairs().any(|(key, _)| key == "chainid")
     }
 }
 
@@ -333,7 +341,7 @@ pub struct ClientBuilder {
     client: Option<reqwest::Client>,
     /// Etherscan API key
     api_key: Option<String>,
-    /// Etherscan API endpoint like <https://api(-chain).etherscan.io/api>
+    /// Etherscan API endpoint like <https://api.etherscan.io/v2/api?chainid=(chain_id)>
     etherscan_api_url: Option<Url>,
     /// Etherscan API version (v2 is new verifier version, v1 is the default)
     etherscan_api_version: EtherscanApiVersion,
@@ -591,6 +599,8 @@ struct Query<'a, T: Serialize> {
     apikey: Option<Cow<'a, str>>,
     module: Cow<'a, str>,
     action: Cow<'a, str>,
+    #[serde(rename = "chainId", skip_serializing_if = "Option::is_none")]
+    chain_id: Option<u64>,
     #[serde(flatten)]
     other: T,
 }


### PR DESCRIPTION
Related: https://github.com/foundry-rs/foundry/pull/10912

Latest `alloy-chains` update causes failures in Foundry: https://github.com/foundry-rs/foundry/actions/runs/16050452390/job/45291650366 due to `chainid` query parameter being set multiple times (once in `alloy-chains` and then again in `query`). We should avoid setting it twice if it already exists.

before:

```
https://api.etherscan.io/v2/api?chainid=137&apikey=<API_KEY>&module=contract&action=getsourcecode&chainid=137&address=0x794a61358d6845594f94dc1db02a252b5b4814ad
```

after (avoid duplicate `chainid` / `chainId`):

```
https://api.etherscan.io/v2/api?chainid=137&apikey=<API_KEY>&module=contract&action=getsourcecode&address=0x794a61358d6845594f94dc1db02a252b5b4814ad
```

Failing without: https://github.com/foundry-rs/foundry/actions/runs/16050452390/job/45291650366

Passing with this change: https://github.com/foundry-rs/foundry/actions/runs/16053887189/job/45303239622