### PR TITLE
fix: alloy-chains `0.2.5` contains breaking changes for block-explorers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ edition = "2021"
 exclude = [".github/", "scripts/", "test-data/"]
 
 [workspace.dependencies]
-alloy-chains = "0.2"
+alloy-chains = "=0.2.4"
 alloy-primitives = { version = "1.0", default-features = false, features = [
     "std",
     "serde",


### PR DESCRIPTION
Etherscan URLs defined in `alloy-chains` now include the `?chainId=` query parameter and this is not accounted for in the `block-explorers` logic

It is technically correct to switch to Etherscan V2 entirely in `alloy-chains` but this means the `block-explorers` logic has to be updated.