### PR TITLE
fix(tests): disambiguate `Into` target for `parse_units` in gas.rs

### DIFF
--- a/crates/block-explorers/src/gas.rs
+++ b/crates/block-explorers/src/gas.rs
@@ -137,7 +137,7 @@ mod tests {
         assert_eq!(gas_oracle.message, "OK");
         assert_eq!(
             gas_oracle.result.propose_gas_price,
-            parse_units("141.9", "gwei").unwrap().into()
+            Into::<U256>::into(parse_units("141.9", "gwei").unwrap())
         );
 
         let v = r#"{
@@ -154,7 +154,10 @@ mod tests {
         }"#;
         let gas_oracle: Response<GasOracle> = serde_json::from_str(v).unwrap();
         assert_eq!(gas_oracle.message, "OK");
-        assert_eq!(gas_oracle.result.propose_gas_price, parse_units(22, "gwei").unwrap().into());
+        assert_eq!(
+            gas_oracle.result.propose_gas_price,
+            Into::<U256>::into(parse_units(22, "gwei").unwrap())
+        );
 
         // remove quotes around integers
         let v = r#"{
@@ -171,6 +174,9 @@ mod tests {
         }"#;
         let gas_oracle: Response<GasOracle> = serde_json::from_str(v).unwrap();
         assert_eq!(gas_oracle.message, "OK");
-        assert_eq!(gas_oracle.result.propose_gas_price, parse_units(22, "gwei").unwrap().into());
+        assert_eq!(
+            gas_oracle.result.propose_gas_price,
+            Into::<U256>::into(parse_units(22, "gwei").unwrap())
+        );
     }
 }


### PR DESCRIPTION
# Description:
This PR updates the `response_works` test in `gas.rs` to specify the target type for `.into()` explicitly calls on parse_units.

Previously, the test failed to compile with [E0283](https://doc.rust-lang.org/error_codes/E0283.html) because `ParseUnits` implements `From` for both `U256` and `I256`, making the `.into()` target type ambiguous.

## Changes:

- Replaced `.into()` with `Into::<U256>::into(...)` in three assertions within `gas.rs `tests.
- No changes to production code.

## Steps to Reproduce (before fix):

```
cargo test -p foundry-block-explorers -- gas::tests::response_works
```

Results in:

```
error[E0283]: type annotations needed
...
```

Fixes: #97 