### PR TITLE
fix: avoid glueing with `chain`, the URL is available directly and correctly in `alloy-chains`.

### DIFF
--- a/crates/block-explorers/src/lib.rs
+++ b/crates/block-explorers/src/lib.rs
@@ -197,7 +197,7 @@ impl Client {
         if self.is_etherscan() && self.chain_id.is_some() && !self.url_contains_chainid() {
             post_query.insert("chainid", self.chain_id.unwrap());
 
-            trace!(target: "etherscan", "QUERY {:?}", post_query);
+            trace!(target: "etherscan", "POST QUERY {:?}", post_query);
         }
 
         let response = self
@@ -260,10 +260,7 @@ impl Client {
     }
 
     fn is_etherscan(&self) -> bool {
-        Url::parse(ETHERSCAN_V2_API_BASE_URL)
-            .ok()
-            .map(|url| self.etherscan_api_url == url)
-            .unwrap_or(false)
+        self.etherscan_api_url.as_str().contains(ETHERSCAN_V2_API_BASE_URL)
     }
 
     fn url_contains_chainid(&self) -> bool {

--- a/crates/block-explorers/src/lib.rs
+++ b/crates/block-explorers/src/lib.rs
@@ -196,6 +196,8 @@ impl Client {
 
         if self.chain_id.is_some() && !self.url_contains_chainid() {
             post_query.insert("chainid", self.chain_id.unwrap());
+
+            trace!(target: "etherscan", "QUERY {:?}", post_query);
         }
 
         let response = self

--- a/crates/block-explorers/src/lib.rs
+++ b/crates/block-explorers/src/lib.rs
@@ -192,15 +192,9 @@ impl Client {
     async fn post<F: Serialize>(&self, form: &F) -> Result<String> {
         trace!(target: "etherscan", "POST {}", self.etherscan_api_url);
 
-        let is_etherscan = Url::parse(ETHERSCAN_V2_API_BASE_URL)
-            .map_err(|_| EtherscanError::Builder("Bad URL Parse".into()))?;
-
         let mut post_query = HashMap::new();
 
-        if self.etherscan_api_url == is_etherscan
-            && self.chain_id.is_some()
-            && !self.url_contains_chainid()
-        {
+        if self.is_etherscan() && self.chain_id.is_some() && !self.url_contains_chainid() {
             post_query.insert("chainid", self.chain_id.unwrap());
 
             trace!(target: "etherscan", "QUERY {:?}", post_query);
@@ -263,6 +257,10 @@ impl Client {
             chain_id: if self.url_contains_chainid() { None } else { self.chain_id },
             other,
         }
+    }
+
+    fn is_etherscan(&self) -> bool {
+        self.etherscan_api_url == Url::parse(ETHERSCAN_V2_API_BASE_URL).unwrap()
     }
 
     fn url_contains_chainid(&self) -> bool {

--- a/crates/block-explorers/src/lib.rs
+++ b/crates/block-explorers/src/lib.rs
@@ -192,9 +192,15 @@ impl Client {
     async fn post<F: Serialize>(&self, form: &F) -> Result<String> {
         trace!(target: "etherscan", "POST {}", self.etherscan_api_url);
 
+        let is_etherscan = Url::parse(ETHERSCAN_V2_API_BASE_URL)
+            .map_err(|_| EtherscanError::Builder("Bad URL Parse".into()))?;
+
         let mut post_query = HashMap::new();
 
-        if self.chain_id.is_some() && !self.url_contains_chainid() {
+        if self.etherscan_api_url == is_etherscan
+            && self.chain_id.is_some()
+            && !self.url_contains_chainid()
+        {
             post_query.insert("chainid", self.chain_id.unwrap());
 
             trace!(target: "etherscan", "QUERY {:?}", post_query);

--- a/crates/block-explorers/src/lib.rs
+++ b/crates/block-explorers/src/lib.rs
@@ -260,7 +260,10 @@ impl Client {
     }
 
     fn is_etherscan(&self) -> bool {
-        self.etherscan_api_url == Url::parse(ETHERSCAN_V2_API_BASE_URL).unwrap()
+        Url::parse(ETHERSCAN_V2_API_BASE_URL)
+            .ok()
+            .map(|url| self.etherscan_api_url == url)
+            .unwrap_or(false)
     }
 
     fn url_contains_chainid(&self) -> bool {

--- a/crates/block-explorers/src/lib.rs
+++ b/crates/block-explorers/src/lib.rs
@@ -300,17 +300,14 @@ impl ClientBuilder {
         ) -> (reqwest::Result<Url>, reqwest::Result<Url>) {
             (api.into_url(), url.into_url())
         }
-        let (_, etherscan_url) = chain
+        let (etherscan_api_url, etherscan_url) = chain
             .named()
             .ok_or_else(|| EtherscanError::ChainNotSupported(chain))?
             .etherscan_urls()
             .map(urls)
             .ok_or_else(|| EtherscanError::ChainNotSupported(chain))?;
 
-        let etherscan_api_url = Url::parse(ETHERSCAN_V2_API_BASE_URL)
-            .map_err(|_| EtherscanError::Builder("Bad URL Parse".into()))?;
-
-        self.with_chain_id(chain).with_api_url(etherscan_api_url)?.with_url(etherscan_url?)
+        self.with_chain_id(chain).with_api_url(etherscan_api_url?)?.with_url(etherscan_url?)
     }
 
     /// Configures the Etherscan url


### PR DESCRIPTION
also avoids any unnecessary insertions of `chainid` as query parameter for other verifiers (though they were tolerant of it)