### PR TITLE
chore(publish): V0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- Release 0.22.0
 - Deprecate Etherscan V1 ([#101](https://github.com/foundry-rs/block-explorers/issues/101))
 - Release 0.21.0 ([#108](https://github.com/foundry-rs/block-explorers/issues/108))
 - Add @0xrusowsky to `CODEOWNERS` ([#105](https://github.com/foundry-rs/block-explorers/issues/105))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.21.0](https://github.com/foundry-rs/block-explorers/releases/tag/v0.21.0) - 2025-08-25
+## [0.22.0](https://github.com/foundry-rs/block-explorers/releases/tag/v0.22.0) - 2025-09-01
 
 ### Bug Fixes
 
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Miscellaneous Tasks
 
+- Deprecate Etherscan V1 ([#101](https://github.com/foundry-rs/block-explorers/issues/101))
+- Release 0.21.0 ([#108](https://github.com/foundry-rs/block-explorers/issues/108))
 - Add @0xrusowsky to `CODEOWNERS` ([#105](https://github.com/foundry-rs/block-explorers/issues/105))
 - Update `CODEOWNERS` to improve visibility ([#103](https://github.com/foundry-rs/block-explorers/issues/103))
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ resolver = "2"
 
 [workspace.package]
 authors = ["Foundry Maintainers"]
-version = "0.21.0"
+version = "0.22.0"
 rust-version = "1.76"
 readme = "README.md"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Branch protection caused direct push to `refs/head/main` to be blocked

```
Enumerating objects: 10, done.
Counting objects: 100% (10/10), done.
Delta compression using up to 32 threads
Compressing objects: 100% (7/7), done.
Writing objects: 100% (7/7), 1.98 KiB | 1.98 MiB/s, done.
Total 7 (delta 5), reused 0 (delta 0), pack-reused 0
remote: Resolving deltas: 100% (5/5), completed with 3 local objects.
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: 
remote: - Changes must be made through a pull request.
To github.com:foundry-rs/block-explorers.git
 ! [remote rejected] main -> main (protected branch hook declined)
error: failed to push some refs to 'github.com:foundry-rs/block-explorers.git'
```