### PR TITLE
chore: remove `doc_auto-cfg`

### DIFF
--- a/crates/blob-explorers/src/lib.rs
+++ b/crates/blob-explorers/src/lib.rs
@@ -8,7 +8,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(unused_must_use, rust_2018_idioms)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use alloy_chains::{Chain, ChainKind, NamedChain};
 use alloy_primitives::B256;

--- a/crates/block-explorers/src/lib.rs
+++ b/crates/block-explorers/src/lib.rs
@@ -9,7 +9,7 @@
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(unused_must_use, rust_2018_idioms)]
-#![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[macro_use]
 extern crate tracing;


### PR DESCRIPTION
This feature was removed.

Unblocks #120 and #122