### PR TITLE
chore: rm fantom

### DIFF
--- a/crates/block-explorers/src/lib.rs
+++ b/crates/block-explorers/src/lib.rs
@@ -482,11 +482,6 @@ fn into_url(url: impl IntoUrl) -> std::result::Result<Url, reqwest::Error> {
 fn get_api_key_from_chain(chain: Chain) -> Result<String, EtherscanError> {
     match chain.kind() {
         ChainKind::Named(named) => match named {
-            // Fantom is special and doesn't support etherscan api v2
-            NamedChain::Fantom | NamedChain::FantomTestnet => std::env::var("FMTSCAN_API_KEY")
-                .or_else(|_| std::env::var("FANTOMSCAN_API_KEY"))
-                .map_err(Into::into),
-
             // Backwards compatibility, ideally these should return an error.
             NamedChain::Gnosis
             | NamedChain::Chiado

--- a/crates/block-explorers/tests/it/account.rs
+++ b/crates/block-explorers/tests/it/account.rs
@@ -191,26 +191,12 @@ async fn get_etherscan_polygon_key_v2() {
 
 #[tokio::test]
 #[serial]
-async fn get_fantom_key_ftmscan() {
-    env::set_var("FMTSCAN_API_KEY", "FANTOMSCAN1");
-
-    run_with_client(Chain::from_named(NamedChain::Fantom), |client| async move {
-        assert_eq!(client.api_key().unwrap(), "FANTOMSCAN1");
-
-        env::set_var("FMTSCAN_API_KEY", "");
-    })
-    .await
-}
-
-#[tokio::test]
-#[serial]
-async fn get_fantom_key_fantomscan() {
-    env::set_var("FANTOMSCAN_API_KEY", "FANTOMSCAN2");
-
-    run_with_client(Chain::from_named(NamedChain::Fantom), |client| async move {
-        assert_eq!(client.api_key().unwrap(), "FANTOMSCAN2");
-
-        env::set_var("FANTOMSCAN_API_KEY", "");
+async fn get_sonic_transactions() {
+    run_with_client(Chain::from_named(NamedChain::Sonic), |client| async move {
+        let txs = client
+            .get_transactions(&"0x1549ea9b546ba9ffb306d78a1e1f304760cc4abf".parse().unwrap(), None)
+            .await;
+        txs.unwrap();
     })
     .await
 }


### PR DESCRIPTION
Fantom no longer exists on Etherscan and is now Sonic, which also supports Etherscan v2