### PR TITLE
ci: add nightly job for flaky tests, skip them in regular CI

### DIFF
--- a/.github/FLAKY_TEST_FAILURE_TEMPLATE.md
+++ b/.github/FLAKY_TEST_FAILURE_TEMPLATE.md
@@ -1,0 +1,10 @@
+---
+title: "bug: flaky tests workflow failed"
+labels: P-normal, T-bug
+---
+
+The nightly flaky tests workflow has failed. This indicates external API rate limiting, RPC reliability issues, or other intermittent failures that may affect users.
+
+Check the [flaky tests workflow page]({{ env.WORKFLOW_URL }}) for details.
+
+This issue was raised by the workflow at `.github/workflows/test-flaky.yml`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,10 @@ jobs:
         if: ${{ matrix.rust == '1.76' }} # MSRV
         run: cargo build --workspace
       # Don't use cargo-nextest since all the tests have to be run sequentially
+      # Skip flaky tests that depend on external APIs (run separately in test-flaky.yml)
       - name: test
         if: ${{ matrix.rust != '1.76' }} # MSRV
-        run: cargo test --workspace
+        run: cargo test --workspace -- --skip flaky_
 
   wasm:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-flaky.yml
+++ b/.github/workflows/test-flaky.yml
@@ -1,0 +1,60 @@
+# Daily CI job to run flaky tests that are excluded from regular CI.
+# Tests prefixed with `flaky_` hit external APIs (Etherscan, Blockscout) and
+# are prone to rate limiting or access changes.
+
+name: test-flaky
+
+permissions: {}
+
+on:
+  schedule:
+    - cron: "0 1 * * *" # Run daily at 1 AM UTC
+  workflow_dispatch: # Needed so we can run it manually
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY || 'I5BXNZYP5GEDWFINGVEZKYIVU2695NPQZB' }}
+
+jobs:
+  test:
+    name: flaky tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+      - name: Test flaky tests
+        run: cargo test --workspace -- flaky_
+
+  # If any of the jobs fail, this will create a normal-priority issue to signal so.
+  issue:
+    name: Open an issue
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: failure()
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_URL: |
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          update_existing: true
+          filename: .github/FLAKY_TEST_FAILURE_TEMPLATE.md

--- a/crates/block-explorers/tests/it/account.rs
+++ b/crates/block-explorers/tests/it/account.rs
@@ -11,7 +11,7 @@ use serial_test::serial;
 
 #[tokio::test]
 #[serial]
-async fn get_ether_balance_single_success() {
+async fn flaky_get_ether_balance_single_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let balance = client
             .get_ether_balance_single(
@@ -26,7 +26,7 @@ async fn get_ether_balance_single_success() {
 
 #[tokio::test]
 #[serial]
-async fn get_ether_balance_multi_success() {
+async fn flaky_get_ether_balance_multi_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let balances = client
             .get_ether_balance_multi(
@@ -43,7 +43,7 @@ async fn get_ether_balance_multi_success() {
 
 #[tokio::test]
 #[serial]
-async fn get_transactions_success() {
+async fn flaky_get_transactions_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let txs = client
             .get_transactions(&"0x4F26FfBe5F04ED43630fdC30A87638d53D0b0876".parse().unwrap(), None)
@@ -55,7 +55,7 @@ async fn get_transactions_success() {
 
 #[tokio::test]
 #[serial]
-async fn get_internal_transactions_success() {
+async fn flaky_get_internal_transactions_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let txs = client
             .get_internal_transactions(
@@ -72,7 +72,7 @@ async fn get_internal_transactions_success() {
 
 #[tokio::test]
 #[serial]
-async fn get_internal_transactions_by_tx_hash_success() {
+async fn flaky_get_internal_transactions_by_tx_hash_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let txs = client
             .get_internal_transactions(
@@ -91,7 +91,7 @@ async fn get_internal_transactions_by_tx_hash_success() {
 
 #[tokio::test]
 #[serial]
-async fn get_erc20_transfer_events_success() {
+async fn flaky_get_erc20_transfer_events_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let txs = client
             .get_erc20_token_transfer_events(
@@ -112,7 +112,7 @@ async fn get_erc20_transfer_events_success() {
 
 #[tokio::test]
 #[serial]
-async fn get_erc721_transfer_events_success() {
+async fn flaky_get_erc721_transfer_events_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let txs = client
             .get_erc721_token_transfer_events(
@@ -130,7 +130,7 @@ async fn get_erc721_transfer_events_success() {
 
 #[tokio::test]
 #[serial]
-async fn get_erc1155_transfer_events_success() {
+async fn flaky_get_erc1155_transfer_events_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let txs = client
             .get_erc1155_token_transfer_events(
@@ -148,7 +148,7 @@ async fn get_erc1155_transfer_events_success() {
 
 #[tokio::test]
 #[serial]
-async fn get_mined_blocks_success() {
+async fn flaky_get_mined_blocks_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         client
             .get_mined_blocks(
@@ -176,7 +176,7 @@ async fn flaky_get_avalanche_transactions() {
 
 #[tokio::test]
 #[serial]
-async fn get_etherscan_polygon_key_v2() {
+async fn flaky_get_etherscan_polygon_key_v2() {
     // This requires the etherscan api key to be set – expected for this test suite.
     let etherscan_test_api_key = env::var("ETHERSCAN_API_KEY").unwrap();
     env::set_var("POLYGONSCAN_API_KEY", "POLYGONSCAN1");
@@ -191,7 +191,7 @@ async fn get_etherscan_polygon_key_v2() {
 
 #[tokio::test]
 #[serial]
-async fn get_sonic_transactions() {
+async fn flaky_get_sonic_transactions() {
     run_with_client(Chain::from_named(NamedChain::Sonic), |client| async move {
         let txs = client
             .get_transactions(&"0x1549ea9b546ba9ffb306d78a1e1f304760cc4abf".parse().unwrap(), None)

--- a/crates/block-explorers/tests/it/account.rs
+++ b/crates/block-explorers/tests/it/account.rs
@@ -164,7 +164,7 @@ async fn get_mined_blocks_success() {
 
 #[tokio::test]
 #[serial]
-async fn get_avalanche_transactions() {
+async fn flaky_get_avalanche_transactions() {
     run_with_client(Chain::from_named(NamedChain::Avalanche), |client| async move {
         let txs = client
             .get_transactions(&"0x1549ea9b546ba9ffb306d78a1e1f304760cc4abf".parse().unwrap(), None)

--- a/crates/block-explorers/tests/it/blocks.rs
+++ b/crates/block-explorers/tests/it/blocks.rs
@@ -5,7 +5,7 @@ use serial_test::serial;
 
 #[tokio::test]
 #[serial]
-async fn check_get_block_by_timestamp_before() {
+async fn flaky_check_get_block_by_timestamp_before() {
     run_with_client(Chain::mainnet(), |client| async move {
         let block_no = client.get_block_by_timestamp(1577836800, "before").await;
         assert!(block_no.is_ok());
@@ -18,7 +18,7 @@ async fn check_get_block_by_timestamp_before() {
 
 #[tokio::test]
 #[serial]
-async fn check_get_block_by_timestamp_after() {
+async fn flaky_check_get_block_by_timestamp_after() {
     run_with_client(Chain::mainnet(), |client| async move {
         let block_no = client.get_block_by_timestamp(1577836800, "after").await;
 

--- a/crates/block-explorers/tests/it/contract.rs
+++ b/crates/block-explorers/tests/it/contract.rs
@@ -35,7 +35,7 @@ async fn flaky_can_fetch_contract_abi() {
 
 #[tokio::test]
 #[serial]
-async fn can_fetch_and_cache_contract_abi() {
+async fn flaky_can_fetch_and_cache_contract_abi() {
     async fn fetch_abi(client: &Client, addr: &str) {
         let abi = client.contract_abi(addr.parse().unwrap()).await.unwrap();
         assert_eq!(abi, serde_json::from_str(DEPOSIT_CONTRACT_ABI).unwrap());
@@ -143,7 +143,7 @@ async fn can_fetch_contract_source_code() {
 
 #[tokio::test]
 #[serial]
-async fn can_get_error_on_unverified_contract() {
+async fn flaky_can_get_error_on_unverified_contract() {
     init_tracing();
     run_with_client(Chain::mainnet(), |client| async move {
         let addr = "0xb5c31a0e22cae98ac08233e512bd627885aa24e5".parse().unwrap();

--- a/crates/block-explorers/tests/it/contract.rs
+++ b/crates/block-explorers/tests/it/contract.rs
@@ -22,7 +22,7 @@ async fn can_fetch_ftm_contract_abi() {
 
 #[tokio::test]
 #[serial]
-async fn can_fetch_contract_abi() {
+async fn flaky_can_fetch_contract_abi() {
     run_with_client(Chain::mainnet(), |client| async move {
         let abi = client
             .contract_abi("0x00000000219ab540356cBB839Cbe05303d7705Fa".parse().unwrap())
@@ -156,7 +156,7 @@ async fn can_get_error_on_unverified_contract() {
 /// Query a contract that has a single string source entry instead of underlying JSON metadata.
 #[tokio::test]
 #[serial]
-async fn can_fetch_contract_source_tree_for_singleton_contract() {
+async fn flaky_can_fetch_contract_source_tree_for_singleton_contract() {
     run_with_client(Chain::mainnet(), |client| async move {
         let meta = client
             .contract_source_code("0x00000000219ab540356cBB839Cbe05303d7705Fa".parse().unwrap())
@@ -208,7 +208,7 @@ async fn can_fetch_contract_source_tree_for_plain_source_code_mapping() {
 
 #[tokio::test]
 #[serial]
-async fn can_fetch_contract_creation_data() {
+async fn flaky_can_fetch_contract_creation_data() {
     run_with_client(Chain::mainnet(), |client| async move {
         client
             .contract_creation_data("0xdac17f958d2ee523a2206206994597c13d831ec7".parse().unwrap())

--- a/crates/block-explorers/tests/it/contract.rs
+++ b/crates/block-explorers/tests/it/contract.rs
@@ -10,7 +10,7 @@ const DEPOSIT_CONTRACT_ABI: &str = include!("../../test-data/deposit_contract.ex
 #[ignore]
 #[tokio::test]
 #[serial]
-async fn can_fetch_ftm_contract_abi() {
+async fn flaky_can_fetch_ftm_contract_abi() {
     run_with_client(Chain::from_named(NamedChain::Fantom), |client| async move {
         let _abi = client
             .contract_abi("0x80AA7cb0006d5DDD91cce684229Ac6e398864606".parse().unwrap())
@@ -55,7 +55,7 @@ async fn flaky_can_fetch_and_cache_contract_abi() {
 
 #[tokio::test]
 #[serial]
-async fn can_fetch_and_cache_contract_source_code() {
+async fn flaky_can_fetch_and_cache_contract_source_code() {
     async fn fetch_source_code(client: &Client, addr: &str) {
         let meta = client.contract_source_code(addr.parse().unwrap()).await.unwrap();
         assert_eq!(meta.items.len(), 1);
@@ -80,7 +80,7 @@ async fn can_fetch_and_cache_contract_source_code() {
 
 #[tokio::test]
 #[serial]
-async fn can_fetch_deposit_contract_source_code_from_blockscout() {
+async fn flaky_can_fetch_deposit_contract_source_code_from_blockscout() {
     let client = Client::builder()
         .with_url("https://eth.blockscout.com")
         .unwrap()
@@ -103,7 +103,7 @@ async fn can_fetch_deposit_contract_source_code_from_blockscout() {
 
 #[tokio::test]
 #[serial]
-async fn can_fetch_other_contract_source_code_from_blockscout() {
+async fn flaky_can_fetch_other_contract_source_code_from_blockscout() {
     let client = Client::builder()
         .with_url("https://eth.blockscout.com")
         .unwrap()
@@ -125,7 +125,7 @@ async fn can_fetch_other_contract_source_code_from_blockscout() {
 
 #[tokio::test]
 #[serial]
-async fn can_fetch_contract_source_code() {
+async fn flaky_can_fetch_contract_source_code() {
     run_with_client(Chain::mainnet(), |client| async move {
         let meta = client
             .contract_source_code("0x00000000219ab540356cBB839Cbe05303d7705Fa".parse().unwrap())
@@ -175,7 +175,7 @@ async fn flaky_can_fetch_contract_source_tree_for_singleton_contract() {
 /// Query a contract that has many source entries as JSON metadata and ensure they are reflected.
 #[tokio::test]
 #[serial]
-async fn can_fetch_contract_source_tree_for_multi_entry_contract() {
+async fn flaky_can_fetch_contract_source_tree_for_multi_entry_contract() {
     run_with_client(Chain::mainnet(), |client| async move {
         let meta = client
             .contract_source_code("0x8d04a8c79cEB0889Bdd12acdF3Fa9D207eD3Ff63".parse().unwrap())
@@ -192,7 +192,7 @@ async fn can_fetch_contract_source_tree_for_multi_entry_contract() {
 /// Query a contract that has a plain source code mapping instead of tagged structures.
 #[tokio::test]
 #[serial]
-async fn can_fetch_contract_source_tree_for_plain_source_code_mapping() {
+async fn flaky_can_fetch_contract_source_tree_for_plain_source_code_mapping() {
     run_with_client(Chain::mainnet(), |client| async move {
         let meta = client
             .contract_source_code("0x68b26dcf21180d2a8de5a303f8cc5b14c8d99c4c".parse().unwrap())
@@ -220,7 +220,7 @@ async fn flaky_can_fetch_contract_creation_data() {
 
 #[tokio::test]
 #[serial]
-async fn error_when_creation_data_for_eoa() {
+async fn flaky_error_when_creation_data_for_eoa() {
     init_tracing();
     run_with_client(Chain::mainnet(), |client| async move {
         let addr = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045".parse().unwrap();

--- a/crates/block-explorers/tests/it/gas.rs
+++ b/crates/block-explorers/tests/it/gas.rs
@@ -5,7 +5,7 @@ use serial_test::serial;
 
 #[tokio::test]
 #[serial]
-async fn gas_estimate_success() {
+async fn flaky_gas_estimate_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let result = client.gas_estimate(U256::from(2000000000u32)).await;
 
@@ -17,7 +17,7 @@ async fn gas_estimate_success() {
 #[tokio::test]
 #[ignore]
 #[serial]
-async fn gas_oracle_success() {
+async fn flaky_gas_oracle_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let result = client.gas_oracle().await;
 

--- a/crates/block-explorers/tests/it/main.rs
+++ b/crates/block-explorers/tests/it/main.rs
@@ -126,7 +126,7 @@ fn init_tracing() {
 }
 
 #[tokio::test]
-async fn check_wrong_etherscan_api_key() {
+async fn flaky_check_wrong_etherscan_api_key() {
     let client = Client::new(Chain::mainnet(), "ABCDEFG").unwrap();
     let resp = client
         .contract_source_code("0xBB9bc244D798123fDe783fCc1C72d3Bb8C189413".parse().unwrap())

--- a/crates/block-explorers/tests/it/transaction.rs
+++ b/crates/block-explorers/tests/it/transaction.rs
@@ -5,7 +5,7 @@ use serial_test::serial;
 
 #[tokio::test]
 #[serial]
-async fn check_contract_execution_status_success() {
+async fn flaky_check_contract_execution_status_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let status = client
             .check_contract_execution_status(
@@ -37,7 +37,7 @@ async fn flaky_check_contract_execution_status_error() {
 
 #[tokio::test]
 #[serial]
-async fn check_transaction_receipt_status_success() {
+async fn flaky_check_transaction_receipt_status_success() {
     run_with_client(Chain::mainnet(), |client| async move {
         let success = client
             .check_transaction_receipt_status(
@@ -52,7 +52,7 @@ async fn check_transaction_receipt_status_success() {
 
 #[tokio::test]
 #[serial]
-async fn check_transaction_receipt_status_failed() {
+async fn flaky_check_transaction_receipt_status_failed() {
     run_with_client(Chain::mainnet(), |client| async move {
         let err = client
             .check_transaction_receipt_status(

--- a/crates/block-explorers/tests/it/transaction.rs
+++ b/crates/block-explorers/tests/it/transaction.rs
@@ -20,7 +20,7 @@ async fn check_contract_execution_status_success() {
 
 #[tokio::test]
 #[serial]
-async fn check_contract_execution_status_error() {
+async fn flaky_check_contract_execution_status_error() {
     run_with_client(Chain::mainnet(), |client| async move {
         let err = client
             .check_contract_execution_status(

--- a/crates/block-explorers/tests/it/version.rs
+++ b/crates/block-explorers/tests/it/version.rs
@@ -2,7 +2,7 @@ use foundry_block_explorers::{errors::EtherscanError, utils::lookup_compiler_ver
 use semver::{BuildMetadata, Prerelease, Version};
 
 #[tokio::test]
-async fn can_lookup_compiler_version_build_metadata() {
+async fn flaky_can_lookup_compiler_version_build_metadata() {
     let v = Version::new(0, 8, 13);
     let version = lookup_compiler_version(&v).await.unwrap();
     assert_eq!(v.major, version.major);


### PR DESCRIPTION
## Summary

Skip flaky external-API-dependent tests in regular CI and run them in a separate daily nightly workflow instead — matching the pattern from `foundry-rs/foundry`.

## Changes

- Prefix all 35 external API integration tests with `flaky_`
- Filter them out of regular CI via `cargo test -- --skip flaky_`
- Add `.github/workflows/test-flaky.yml`: daily cron job that runs only `flaky_` tests
- Add `.github/FLAKY_TEST_FAILURE_TEMPLATE.md`: auto-opens an issue on nightly failure

## Why all integration tests?

All integration tests hit Etherscan/Blockscout APIs with a shared free API key rate-limited to 3 calls/sec. Any combination of tests can trigger cascading rate limit failures, making the entire test suite inherently flaky in CI.

Only 2 pure unit tests remain in regular CI:
- `internal_transaction_tests::test_internal_transaction_serialization_deserialization`
- `version::errors_on_invalid_solc`

Prompted by: zerosnacks