### PR TITLE
chore: update to rust edition 2024, rust-version 1.93, and add workspace lint rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest"]
-        rust: ["stable", "1.76"] # MSRV
+        rust: ["stable", "1.93"] # MSRV
     steps:
       - uses: actions/checkout@v6
         with:
@@ -41,11 +41,11 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
       # Only run tests on latest stable and above
       - name: build
-        if: ${{ matrix.rust == '1.76' }} # MSRV
+        if: ${{ matrix.rust == '1.93' }} # MSRV
         run: cargo build --workspace
       # Don't use cargo-nextest since all the tests have to be run sequentially
       - name: test
-        if: ${{ matrix.rust != '1.76' }} # MSRV
+        if: ${{ matrix.rust != '1.93' }} # MSRV
         run: cargo test --workspace
 
   wasm:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,45 @@
 [workspace]
 members = ["crates/*"]
 
-# Explicitly set the resolver to version 2, which is the default for packages with edition >= 2021
-# https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 authors = ["Foundry Maintainers"]
 version = "0.22.0"
-rust-version = "1.76"
+rust-version = "1.93"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/foundry-rs/block-explorers"
 homepage = "https://github.com/foundry-rs/block-explorers"
-edition = "2021"
+edition = "2024"
 exclude = [".github/", "scripts/", "test-data/"]
+
+[workspace.lints.clippy]
+borrow_as_ptr = "warn"
+branches_sharing_code = "warn"
+clear_with_drain = "warn"
+cloned_instead_of_copied = "warn"
+collection_is_never_read = "warn"
+dbg-macro = "warn"
+explicit_iter_loop = "warn"
+manual-string-new = "warn"
+uninlined-format-args = "warn"
+use-self = "warn"
+redundant-clone = "warn"
+octal-escapes = "allow"
+# until <https://github.com/rust-lang/rust-clippy/issues/13885> is fixed
+literal-string-with-formatting-args = "allow"
+result_large_err = "allow"
+
+[workspace.lints.rust]
+redundant_imports = "warn"
+redundant-lifetimes = "warn"
+rust-2018-idioms = "warn"
+unused-must-use = "warn"
+# unreachable-pub = "warn"
+
+[workspace.lints.rustdoc]
+all = "warn"
 
 [workspace.dependencies]
 alloy-chains = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ manual-string-new = "warn"
 uninlined-format-args = "warn"
 use-self = "warn"
 redundant-clone = "warn"
-octal-escapes = "allow"
 # until <https://github.com/rust-lang/rust-clippy/issues/13885> is fixed
 literal-string-with-formatting-args = "allow"
 result_large_err = "allow"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ When updating this, also update:
 
 We will keep a rolling MSRV (minimum supported rust version) policy of **at
 least** 6 months. When increasing the MSRV, the new Rust version must have been
-released at least six months ago. The current MSRV is 1.76.0.
+released at least six months ago. The current MSRV is 1.93.0.
 
 Note that the MSRV is not increased automatically, and only as part of a minor
 release.

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,5 +1,1 @@
 msrv = "1.93"
-
-# `bytes::Bytes` is included by default and `alloy_primitives::Bytes` is a wrapper around it,
-# so it is safe to ignore it as well.
-ignore-interior-mutability = ["bytes::Bytes", "alloy_primitives::Bytes"]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,5 @@
-msrv = "1.76"
+msrv = "1.93"
+
+# `bytes::Bytes` is included by default and `alloy_primitives::Bytes` is a wrapper around it,
+# so it is safe to ignore it as well.
+ignore-interior-mutability = ["bytes::Bytes", "alloy_primitives::Bytes"]

--- a/crates/blob-explorers/Cargo.toml
+++ b/crates/blob-explorers/Cargo.toml
@@ -12,6 +12,9 @@ homepage.workspace = true
 repository.workspace = true
 exclude.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 alloy-chains.workspace = true
 alloy-primitives = { workspace = true, default-features = false, features = [

--- a/crates/blob-explorers/src/request.rs
+++ b/crates/blob-explorers/src/request.rs
@@ -1,6 +1,6 @@
 //! Request types for the Blobscan API.
 
-use serde::{ser::SerializeStruct, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, ser::SerializeStruct};
 
 /// Additional query parameters for the `blocks` endpoint.
 ///

--- a/crates/blob-explorers/src/response.rs
+++ b/crates/blob-explorers/src/response.rs
@@ -2,7 +2,7 @@
 #![allow(missing_docs)]
 
 use alloy_eips::eip4844::Blob;
-use alloy_primitives::{Address, FixedBytes, B256};
+use alloy_primitives::{Address, B256, FixedBytes};
 use alloy_rpc_types_eth::BlobTransactionSidecar;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;

--- a/crates/block-explorers/Cargo.toml
+++ b/crates/block-explorers/Cargo.toml
@@ -12,6 +12,9 @@ homepage.workspace = true
 repository.workspace = true
 exclude.workspace = true
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/block-explorers/README.md
+++ b/crates/block-explorers/README.md
@@ -43,7 +43,7 @@ When updating this, also update:
 
 Foundry will keep a rolling MSRV (minimum supported rust version) policy of **at
 least** 6 months. When increasing the MSRV, the new Rust version must have been
-released at least six months ago. The current MSRV is 1.76.0.
+released at least six months ago. The current MSRV is 1.93.0.
 
 Note that the MSRV is not increased automatically, and only as part of a minor
 release.

--- a/crates/block-explorers/src/account.rs
+++ b/crates/block-explorers/src/account.rs
@@ -1,13 +1,13 @@
 use crate::{
+    Client, EtherscanError, Query, Response, Result,
     block_number::BlockNumber,
     serde_helpers::{
         deserialize_stringified_block_number, deserialize_stringified_numeric,
         deserialize_stringified_numeric_opt, deserialize_stringified_u64,
         deserialize_stringified_u64_opt,
     },
-    Client, EtherscanError, Query, Response, Result,
 };
-use alloy_primitives::{Address, Bytes, B256, U256};
+use alloy_primitives::{Address, B256, Bytes, U256};
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
@@ -25,8 +25,8 @@ pub struct AccountBalance {
 mod genesis_string {
     use super::*;
     use serde::{
-        de::{DeserializeOwned, Error as _},
         Deserializer, Serializer,
+        de::{DeserializeOwned, Error as _},
     };
 
     pub(crate) fn serialize<T, S>(
@@ -54,7 +54,7 @@ mod genesis_string {
         let json = Cow::<'de, str>::deserialize(deserializer)?;
         if !json.is_empty() && !json.starts_with("GENESIS") {
             //wrapping it in quotes to make it valid JSON before parsing
-            serde_json::from_str(&format!("\"{}\"", json))
+            serde_json::from_str(&format!("\"{json}\""))
                 .map(GenesisOption::Some)
                 .map_err(D::Error::custom)
         } else if json.starts_with("GENESIS") {
@@ -68,9 +68,9 @@ mod genesis_string {
 mod json_string {
     use super::*;
     use serde::{
+        Deserializer, Serializer,
         de::{DeserializeOwned, Error as _},
         ser::Error as _,
-        Deserializer, Serializer,
     };
 
     pub(crate) fn serialize<T, S>(
@@ -128,12 +128,12 @@ impl<T> From<GenesisOption<T>> for Option<T> {
 
 impl<T> GenesisOption<T> {
     pub fn is_genesis(&self) -> bool {
-        matches!(self, GenesisOption::Genesis)
+        matches!(self, Self::Genesis)
     }
 
     pub fn value(&self) -> Option<&T> {
         match self {
-            GenesisOption::Some(value) => Some(value),
+            Self::Some(value) => Some(value),
             _ => None,
         }
     }
@@ -336,9 +336,9 @@ pub enum Tag {
 impl Display for Tag {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::result::Result<(), Error> {
         match self {
-            Tag::Earliest => write!(f, "earliest"),
-            Tag::Pending => write!(f, "pending"),
-            Tag::Latest => write!(f, "latest"),
+            Self::Earliest => write!(f, "earliest"),
+            Self::Pending => write!(f, "pending"),
+            Self::Latest => write!(f, "latest"),
         }
     }
 }
@@ -353,8 +353,8 @@ pub enum Sort {
 impl Display for Sort {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::result::Result<(), Error> {
         match self {
-            Sort::Asc => write!(f, "asc"),
-            Sort::Desc => write!(f, "desc"),
+            Self::Asc => write!(f, "asc"),
+            Self::Desc => write!(f, "desc"),
         }
     }
 }
@@ -415,15 +415,15 @@ impl TokenQueryOption {
     pub fn into_params(self, list_params: TxListParams) -> HashMap<&'static str, String> {
         let mut params: HashMap<&'static str, String> = list_params.into();
         match self {
-            TokenQueryOption::ByAddress(address) => {
+            Self::ByAddress(address) => {
                 params.insert("address", format!("{address:?}"));
                 params
             }
-            TokenQueryOption::ByContract(contract) => {
+            Self::ByContract(contract) => {
                 params.insert("contractaddress", format!("{contract:?}"));
                 params
             }
-            TokenQueryOption::ByAddressAndContract(address, contract) => {
+            Self::ByAddressAndContract(address, contract) => {
                 params.insert("address", format!("{address:?}"));
                 params.insert("contractaddress", format!("{contract:?}"));
                 params
@@ -443,8 +443,8 @@ pub enum BlockType {
 impl Display for BlockType {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::result::Result<(), Error> {
         match self {
-            BlockType::CanonicalBlocks => write!(f, "blocks"),
-            BlockType::Uncles => write!(f, "uncles"),
+            Self::CanonicalBlocks => write!(f, "blocks"),
+            Self::Uncles => write!(f, "uncles"),
         }
     }
 }

--- a/crates/block-explorers/src/block_number.rs
+++ b/crates/block-explorers/src/block_number.rs
@@ -24,45 +24,45 @@ impl BlockNumber {
     /// Returns the numeric block number if explicitly set
     pub fn as_number(&self) -> Option<U64> {
         match *self {
-            BlockNumber::Number(num) => Some(num),
+            Self::Number(num) => Some(num),
             _ => None,
         }
     }
 
     /// Returns `true` if a numeric block number is set
     pub fn is_number(&self) -> bool {
-        matches!(self, BlockNumber::Number(_))
+        matches!(self, Self::Number(_))
     }
 
     /// Returns `true` if it's "latest"
     pub fn is_latest(&self) -> bool {
-        matches!(self, BlockNumber::Latest)
+        matches!(self, Self::Latest)
     }
 
     /// Returns `true` if it's "finalized"
     pub fn is_finalized(&self) -> bool {
-        matches!(self, BlockNumber::Finalized)
+        matches!(self, Self::Finalized)
     }
 
     /// Returns `true` if it's "safe"
     pub fn is_safe(&self) -> bool {
-        matches!(self, BlockNumber::Safe)
+        matches!(self, Self::Safe)
     }
 
     /// Returns `true` if it's "pending"
     pub fn is_pending(&self) -> bool {
-        matches!(self, BlockNumber::Pending)
+        matches!(self, Self::Pending)
     }
 
     /// Returns `true` if it's "earliest"
     pub fn is_earliest(&self) -> bool {
-        matches!(self, BlockNumber::Earliest)
+        matches!(self, Self::Earliest)
     }
 }
 
 impl<T: Into<U64>> From<T> for BlockNumber {
     fn from(num: T) -> Self {
-        BlockNumber::Number(num.into())
+        Self::Number(num.into())
     }
 }
 
@@ -72,12 +72,12 @@ impl Serialize for BlockNumber {
         S: Serializer,
     {
         match *self {
-            BlockNumber::Number(ref x) => serializer.serialize_str(&format!("0x{x:x}")),
-            BlockNumber::Latest => serializer.serialize_str("latest"),
-            BlockNumber::Finalized => serializer.serialize_str("finalized"),
-            BlockNumber::Safe => serializer.serialize_str("safe"),
-            BlockNumber::Earliest => serializer.serialize_str("earliest"),
-            BlockNumber::Pending => serializer.serialize_str("pending"),
+            Self::Number(ref x) => serializer.serialize_str(&format!("0x{x:x}")),
+            Self::Latest => serializer.serialize_str("latest"),
+            Self::Finalized => serializer.serialize_str("finalized"),
+            Self::Safe => serializer.serialize_str("safe"),
+            Self::Earliest => serializer.serialize_str("earliest"),
+            Self::Pending => serializer.serialize_str("pending"),
         }
     }
 }
@@ -113,12 +113,12 @@ impl FromStr for BlockNumber {
 impl fmt::Display for BlockNumber {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            BlockNumber::Number(ref x) => format!("0x{x:x}").fmt(f),
-            BlockNumber::Latest => f.write_str("latest"),
-            BlockNumber::Finalized => f.write_str("finalized"),
-            BlockNumber::Safe => f.write_str("safe"),
-            BlockNumber::Earliest => f.write_str("earliest"),
-            BlockNumber::Pending => f.write_str("pending"),
+            Self::Number(x) => format!("0x{x:x}").fmt(f),
+            Self::Latest => f.write_str("latest"),
+            Self::Finalized => f.write_str("finalized"),
+            Self::Safe => f.write_str("safe"),
+            Self::Earliest => f.write_str("earliest"),
+            Self::Pending => f.write_str("pending"),
         }
     }
 }

--- a/crates/block-explorers/src/blocks.rs
+++ b/crates/block-explorers/src/blocks.rs
@@ -1,4 +1,4 @@
-use crate::{block_number::BlockNumber, Client, EtherscanError, Response, Result};
+use crate::{Client, EtherscanError, Response, Result, block_number::BlockNumber};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/crates/block-explorers/src/contract.rs
+++ b/crates/block-explorers/src/contract.rs
@@ -1,21 +1,21 @@
 use crate::{
+    Client, EtherscanError, Response, Result,
     serde_helpers::{deserialize_stringified_bool_or_u64, deserialize_stringified_u64},
     source_tree::{SourceTree, SourceTreeEntry},
     utils::{deserialize_address_opt, deserialize_source_code},
-    Client, EtherscanError, Response, Result,
 };
 use alloy_json_abi::JsonAbi;
-use alloy_primitives::{Address, Bytes, B256};
+use alloy_primitives::{Address, B256, Bytes};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::Path};
 
 #[cfg(feature = "foundry-compilers")]
 use foundry_compilers::{
+    ProjectBuilder, SolcConfig,
     artifacts::{EvmVersion, Settings},
     compilers::solc::SolcCompiler,
     solc::SolcSettings,
-    ProjectBuilder, SolcConfig,
 };
 
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
@@ -187,11 +187,7 @@ impl Metadata {
     /// Returns the contract's programming language.
     pub fn language(&self) -> SourceCodeLanguage {
         self.source_code.language().unwrap_or_else(|| {
-            if self.is_vyper() {
-                SourceCodeLanguage::Vyper
-            } else {
-                SourceCodeLanguage::Solidity
-            }
+            if self.is_vyper() { SourceCodeLanguage::Vyper } else { SourceCodeLanguage::Solidity }
         })
     }
 

--- a/crates/block-explorers/src/errors.rs
+++ b/crates/block-explorers/src/errors.rs
@@ -46,9 +46,13 @@ pub enum EtherscanError {
     InvalidApiKey,
     #[error("Invalid API Version")]
     InvalidApiVersion,
-    #[error("Sorry, you have been blocked by Cloudflare, See also https://community.cloudflare.com/t/sorry-you-have-been-blocked/110790")]
+    #[error(
+        "Sorry, you have been blocked by Cloudflare, See also https://community.cloudflare.com/t/sorry-you-have-been-blocked/110790"
+    )]
     BlockedByCloudflare,
-    #[error("The Requested prompted a cloudflare captcha security challenge to review the security of your connection before proceeding.")]
+    #[error(
+        "The Requested prompted a cloudflare captcha security challenge to review the security of your connection before proceeding."
+    )]
     CloudFlareSecurityChallenge,
     #[error("Received `Page not found` response. API server is likely down")]
     PageNotFound,

--- a/crates/block-explorers/src/gas.rs
+++ b/crates/block-explorers/src/gas.rs
@@ -1,6 +1,6 @@
-use crate::{utils::parse_units, Client, EtherscanError, Response, Result};
+use crate::{Client, EtherscanError, Response, Result, utils::parse_units};
 use alloy_primitives::U256;
-use serde::{de, Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, de};
 use std::{collections::HashMap, str::FromStr};
 
 const WEI_PER_GWEI: u64 = 1_000_000_000;

--- a/crates/block-explorers/src/lib.rs
+++ b/crates/block-explorers/src/lib.rs
@@ -20,8 +20,8 @@ use alloy_json_abi::JsonAbi;
 use alloy_primitives::{Address, B256};
 use contract::ContractMetadata;
 use errors::EtherscanError;
-use reqwest::{header, IntoUrl, Url};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use reqwest::{IntoUrl, Url, header};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::{
     borrow::Cow,
     io::Write,
@@ -94,12 +94,12 @@ impl Client {
 
     /// Create a new client with the correct endpoints based on the chain and provided API key
     pub fn new(chain: Chain, api_key: impl Into<String>) -> Result<Self> {
-        Client::builder().with_api_key(api_key).chain(chain)?.build()
+        Self::builder().with_api_key(api_key).chain(chain)?.build()
     }
 
     /// Create a new client with the correct endpoint with the chain
     pub fn new_from_env(chain: Chain) -> Result<Self> {
-        Client::builder().with_api_key(get_api_key_from_chain(chain)?).chain(chain)?.build()
+        Self::builder().with_api_key(get_api_key_from_chain(chain)?).chain(chain)?.build()
     }
 
     /// Create a new client with the correct endpoints based on the chain and API key
@@ -330,13 +330,12 @@ impl ClientBuilder {
     ///   - `etherscan_api_url`
     ///   - `etherscan_url`
     pub fn build(self) -> Result<Client> {
-        let ClientBuilder { client, api_key, etherscan_api_url, etherscan_url, cache } = self;
+        let Self { client, api_key, etherscan_api_url, etherscan_url, cache } = self;
 
         let client = Client {
             client: client.unwrap_or_default(),
             api_key,
             etherscan_api_url: etherscan_api_url
-                .clone()
                 .ok_or_else(|| EtherscanError::Builder("etherscan api url".to_string()))?,
             etherscan_url: etherscan_url
                 .ok_or_else(|| EtherscanError::Builder("etherscan url".to_string()))?,

--- a/crates/block-explorers/src/serde_helpers.rs
+++ b/crates/block-explorers/src/serde_helpers.rs
@@ -1,5 +1,5 @@
 use crate::block_number::BlockNumber;
-use alloy_primitives::{U256, U64};
+use alloy_primitives::{U64, U256};
 use serde::{Deserialize, Deserializer};
 use std::str::FromStr;
 
@@ -19,18 +19,18 @@ impl TryFrom<StringifiedNumeric> for U256 {
         match value {
             StringifiedNumeric::U256(n) => Ok(n),
             StringifiedNumeric::Num(n) => {
-                Ok(U256::from_str(&n.to_string()).map_err(|err| err.to_string())?)
+                Ok(Self::from_str(&n.to_string()).map_err(|err| err.to_string())?)
             }
             StringifiedNumeric::String(s) => {
                 if let Ok(val) = s.parse::<u128>() {
-                    Ok(U256::from(val))
+                    Ok(Self::from(val))
                 } else if s.starts_with("0x") {
                     // from_str_radix expects ONLY hex digits (0-9, A-F)
                     // E.g from_str_radix("0xff", 16) will fail because 'x' is not a hex digit
-                    U256::from_str_radix(s.strip_prefix("0x").unwrap(), 16)
+                    Self::from_str_radix(s.strip_prefix("0x").unwrap(), 16)
                         .map_err(|err| err.to_string())
                 } else {
-                    U256::from_str(&s).map_err(|err| err.to_string())
+                    Self::from_str(&s).map_err(|err| err.to_string())
                 }
             }
         }
@@ -42,7 +42,7 @@ impl TryFrom<StringifiedNumeric> for U64 {
 
     fn try_from(value: StringifiedNumeric) -> Result<Self, Self::Error> {
         let value = U256::try_from(value)?;
-        Ok(value.wrapping_to::<U64>())
+        Ok(value.wrapping_to::<Self>())
     }
 }
 
@@ -143,11 +143,11 @@ impl TryFrom<StringifiedBlockNumber> for BlockNumber {
         match value {
             StringifiedBlockNumber::BlockNumber(b) => Ok(b),
             StringifiedBlockNumber::Numeric(num) => match num {
-                StringifiedNumeric::String(s) => BlockNumber::from_str(&s),
+                StringifiedNumeric::String(s) => Self::from_str(&s),
                 other => {
                     let u256 = U256::try_from(other)?;
                     let n = u64::try_from(u256).map_err(|e| e.to_string())?;
-                    Ok(BlockNumber::Number(U64::from(n)))
+                    Ok(Self::Number(U64::from(n)))
                 }
             },
         }

--- a/crates/block-explorers/src/units.rs
+++ b/crates/block-explorers/src/units.rs
@@ -32,7 +32,7 @@ impl TryFrom<u32> for Units {
     type Error = ConversionError;
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
-        Ok(Units::Other(value))
+        Ok(Self::Other(value))
     }
 }
 
@@ -40,7 +40,7 @@ impl TryFrom<i32> for Units {
     type Error = ConversionError;
 
     fn try_from(value: i32) -> Result<Self, Self::Error> {
-        Ok(Units::Other(value as u32))
+        Ok(Self::Other(value as u32))
     }
 }
 
@@ -48,7 +48,7 @@ impl TryFrom<usize> for Units {
     type Error = ConversionError;
 
     fn try_from(value: usize) -> Result<Self, Self::Error> {
-        Ok(Units::Other(value as u32))
+        Ok(Self::Other(value as u32))
     }
 }
 
@@ -81,13 +81,13 @@ impl FromStr for Units {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(match s.to_lowercase().as_str() {
-            "eth" | "ether" => Units::Ether,
-            "pwei" | "milli" | "milliether" | "finney" => Units::Pwei,
-            "twei" | "micro" | "microether" | "szabo" => Units::Twei,
-            "gwei" | "nano" | "nanoether" | "shannon" => Units::Gwei,
-            "mwei" | "pico" | "picoether" | "lovelace" => Units::Mwei,
-            "kwei" | "femto" | "femtoether" | "babbage" => Units::Kwei,
-            "wei" => Units::Wei,
+            "eth" | "ether" => Self::Ether,
+            "pwei" | "milli" | "milliether" | "finney" => Self::Pwei,
+            "twei" | "micro" | "microether" | "szabo" => Self::Twei,
+            "gwei" | "nano" | "nanoether" | "shannon" => Self::Gwei,
+            "mwei" | "pico" | "picoether" | "lovelace" => Self::Mwei,
+            "kwei" | "femto" | "femtoether" | "babbage" => Self::Kwei,
+            "wei" => Self::Wei,
             _ => return Err(ConversionError::UnrecognizedUnits(s.to_string())),
         })
     }
@@ -101,27 +101,27 @@ impl From<Units> for u32 {
 
 impl From<Units> for i32 {
     fn from(units: Units) -> Self {
-        units.as_num() as i32
+        units.as_num() as Self
     }
 }
 
 impl From<Units> for usize {
     fn from(units: Units) -> Self {
-        units.as_num() as usize
+        units.as_num() as Self
     }
 }
 
 impl Units {
     pub fn as_num(&self) -> u32 {
         match self {
-            Units::Wei => 0,
-            Units::Kwei => 3,
-            Units::Mwei => 6,
-            Units::Gwei => 9,
-            Units::Twei => 12,
-            Units::Pwei => 15,
-            Units::Ether => 18,
-            Units::Other(inner) => *inner,
+            Self::Wei => 0,
+            Self::Kwei => 3,
+            Self::Mwei => 6,
+            Self::Gwei => 9,
+            Self::Twei => 12,
+            Self::Pwei => 15,
+            Self::Ether => 18,
+            Self::Other(inner) => *inner,
         }
     }
 }

--- a/crates/block-explorers/src/utils.rs
+++ b/crates/block-explorers/src/utils.rs
@@ -1,5 +1,5 @@
-use crate::{contract::SourceCodeMetadata, units::Units, EtherscanError, Result};
-use alloy_primitives::{Address, ParseSignedError, I256, U256};
+use crate::{EtherscanError, Result, contract::SourceCodeMetadata, units::Units};
+use alloy_primitives::{Address, I256, ParseSignedError, U256};
 use semver::Version;
 use serde::{Deserialize, Deserializer};
 use std::{fmt, str::FromStr};
@@ -90,7 +90,7 @@ impl From<ParseUnits> for I256 {
     fn from(n: ParseUnits) -> Self {
         match n {
             ParseUnits::I256(n) => n,
-            ParseUnits::U256(n) => I256::from_raw(n),
+            ParseUnits::U256(n) => Self::from_raw(n),
         }
     }
 }
@@ -104,8 +104,8 @@ impl From<alloy_primitives::Signed<256, 4>> for ParseUnits {
 impl fmt::Display for ParseUnits {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ParseUnits::U256(val) => val.fmt(f),
-            ParseUnits::I256(val) => val.fmt(f),
+            Self::U256(val) => val.fmt(f),
+            Self::I256(val) => val.fmt(f),
         }
     }
 }

--- a/crates/block-explorers/src/verify.rs
+++ b/crates/block-explorers/src/verify.rs
@@ -79,11 +79,7 @@ impl VerifyContract {
     }
 
     pub fn optimization(self, optimization: bool) -> Self {
-        if optimization {
-            self.optimized()
-        } else {
-            self.not_optimized()
-        }
+        if optimization { self.optimized() } else { self.not_optimized() }
     }
 
     pub fn optimized(mut self) -> Self {
@@ -155,9 +151,9 @@ pub enum CodeFormat {
 impl AsRef<str> for CodeFormat {
     fn as_ref(&self) -> &str {
         match self {
-            CodeFormat::SingleFile => "solidity-single-file",
-            CodeFormat::StandardJsonInput => "solidity-standard-json-input",
-            CodeFormat::VyperJson => "vyper-json",
+            Self::SingleFile => "solidity-single-file",
+            Self::StandardJsonInput => "solidity-standard-json-input",
+            Self::VyperJson => "vyper-json",
         }
     }
 }

--- a/crates/block-explorers/tests/it/account.rs
+++ b/crates/block-explorers/tests/it/account.rs
@@ -2,7 +2,7 @@ use std::env;
 
 use crate::run_with_client;
 use alloy_chains::{Chain, NamedChain};
-use alloy_primitives::{U256, U64};
+use alloy_primitives::{U64, U256};
 use foundry_block_explorers::{
     account::{InternalTxQueryOption, TokenQueryOption},
     block_number::BlockNumber,
@@ -179,12 +179,14 @@ async fn get_avalanche_transactions() {
 async fn get_etherscan_polygon_key_v2() {
     // This requires the etherscan api key to be set – expected for this test suite.
     let etherscan_test_api_key = env::var("ETHERSCAN_API_KEY").unwrap();
-    env::set_var("POLYGONSCAN_API_KEY", "POLYGONSCAN1");
+    // SAFETY: This test is run serially so no other threads are reading env vars.
+    unsafe { env::set_var("POLYGONSCAN_API_KEY", "POLYGONSCAN1") };
 
     run_with_client(Chain::from_named(NamedChain::Polygon), |client| async move {
         assert_eq!(client.api_key().unwrap(), etherscan_test_api_key);
 
-        env::set_var("POLYGONSCAN_API_KEY", "");
+        // SAFETY: This test is run serially so no other threads are reading env vars.
+        unsafe { env::set_var("POLYGONSCAN_API_KEY", "") };
     })
     .await
 }
@@ -230,7 +232,7 @@ mod internal_transaction_tests {
             gas_used: U256::from(3209972u64),
             trace_id: "0_1_1".to_string(),
             is_error: "0".to_string(),
-            err_code: "".to_string(),
+            err_code: String::new(),
         };
 
         // Serialize to JSON
@@ -258,7 +260,7 @@ mod internal_transaction_tests {
             (GenesisOption::Some(original), GenesisOption::Some(deserialized)) => {
                 assert_eq!(original, deserialized);
             }
-            (a, b) => panic!("Contract address mismatch: {:?} != {:?}", a, b),
+            (a, b) => panic!("Contract address mismatch: {a:?} != {b:?}"),
         }
         assert_eq!(internal_tx.hash, deserialized.hash);
         assert_eq!(internal_tx.from, deserialized.from);

--- a/crates/block-explorers/tests/it/contract.rs
+++ b/crates/block-explorers/tests/it/contract.rs
@@ -1,6 +1,6 @@
 use crate::{init_tracing, run_with_client, run_with_client_cached};
 use alloy_chains::{Chain, NamedChain};
-use foundry_block_explorers::{contract::SourceCodeMetadata, errors::EtherscanError, Client};
+use foundry_block_explorers::{Client, contract::SourceCodeMetadata, errors::EtherscanError};
 use serial_test::serial;
 
 /// Abi of [0x00000000219ab540356cBB839Cbe05303d7705Fa](https://api.etherscan.io/api?module=contract&action=getsourcecode&address=0x00000000219ab540356cBB839Cbe05303d7705Fa).

--- a/crates/block-explorers/tests/it/main.rs
+++ b/crates/block-explorers/tests/it/main.rs
@@ -3,10 +3,9 @@
 #![cfg(not(target_arch = "wasm32"))]
 
 use alloy_chains::{Chain, ChainKind, NamedChain};
-use foundry_block_explorers::{errors::EtherscanError, Client};
+use foundry_block_explorers::{Client, errors::EtherscanError};
 use std::{
     env,
-    future::Future,
     path::PathBuf,
     time::{Duration, Instant},
 };

--- a/crates/block-explorers/tests/it/verify.rs
+++ b/crates/block-explorers/tests/it/verify.rs
@@ -3,10 +3,10 @@
 use crate::run_with_client;
 use alloy_chains::Chain;
 use foundry_block_explorers::verify::{CodeFormat, VerifyContract};
-use foundry_compilers::{solc::SolcLanguage, Project, ProjectPathsConfig};
+use foundry_compilers::{Project, ProjectPathsConfig, solc::SolcLanguage};
 use serial_test::serial;
 use std::path::Path;
-use tokio::time::{sleep, Duration};
+use tokio::time::{Duration, sleep};
 use tracing::trace;
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Update workspace to Rust edition 2024 / MSRV 1.93 and add workspace lint rules matching `foundry-rs/foundry`.

## Changes

- `edition`: 2021 → 2024
- `rust-version`: 1.76 → 1.93
- `resolver`: 2 → 3
- `clippy.toml` MSRV: 1.76 → 1.93, add `ignore-interior-mutability`
- CI workflow + README MSRV references updated
- Add `[workspace.lints.clippy]`, `[workspace.lints.rust]`, `[workspace.lints.rustdoc]` matching `foundry-rs/foundry`
- Add `[lints] workspace = true` to both crates

## Edition 2024 fixes

- Removed explicit `ref` in match pattern (`block_number.rs`)
- Wrapped `env::set_var` in `unsafe` blocks (`account.rs` tests) — now unsafe in edition 2024
- Reformatted imports per edition 2024 rustfmt style

## Lint fixes

- `use-self`: replaced type names with `Self` in impl blocks
- `uninlined-format-args`: inlined format arguments
- `redundant-clone`: removed unnecessary `.clone()`
- `redundant-imports`: removed `Future` import (now in edition 2024 prelude)

Ref: https://github.com/foundry-rs/block-explorers/pull/160