### PR TITLE
chore(deps): bump alloy-eips, alloy-serde, alloy-rpc-types-eth to 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ alloy-primitives = { version = "1.3", default-features = false, features = [
     "serde",
 ] }
 alloy-json-abi = { version = "1.3", default-features = false }
-alloy-rpc-types-eth = "1.0"
-alloy-eips = "1.0"
-alloy-serde = "1.0"
+alloy-rpc-types-eth = "2.0"
+alloy-eips = "2.0"
+alloy-serde = "2.0"
 
 reqwest = { version = "0.13", default-features = false, features = ["json", "query", "form"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Bump alloy deps from 1.0 to 2.0:

- `alloy-rpc-types-eth`: 1.0 → 2.0
- `alloy-eips`: 1.0 → 2.0
- `alloy-serde`: 1.0 → 2.0

`alloy-json-abi` and `alloy-primitives` remain on 1.x as alloy-core hasn't released 2.0.

No breaking changes for this codebase — builds and passes clippy cleanly.

Prompted by: mattsse